### PR TITLE
Reparar .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,7 @@ Todo.txt
 __pycache__/
 temp/
 local_settings.py
-migrations/
+
+/static
+/media
+my_db.cnf


### PR DESCRIPTION
Este PR es para asegurarse que se ignora:
 - El archivo de configuracion de la base de datos cuando se usa MySQL (se usa para credenciales)
 - /static: Esta carpeta en la raiz del proyecto se construye con el `collecstatic` y no debe ser parte del repo para no repetir los archivos static de las apps
 - /media Alli se graban los archivos que los usuarios suben, no deben ser parte del repo

